### PR TITLE
Fix: Separate compareScoreChart into Component and Change Design

### DIFF
--- a/src/routes/HealthCare/Chart/CompareScoreChart/compareScoreChart.module.scss
+++ b/src/routes/HealthCare/Chart/CompareScoreChart/compareScoreChart.module.scss
@@ -1,0 +1,34 @@
+@use '/src/styles/constants/colors';
+
+.comparativeChart {
+  display: flex;
+  flex-direction: column;
+  color: colors.$MAIN_FONT;
+
+  .chartTitle {
+    margin: 20px 0;
+    font-size: 20px;
+    font-weight: 700;
+  }
+
+  .description {
+    line-height: 1.5;
+  }
+
+  .highlight {
+    display: inline-block;
+    padding-bottom: 0.5em;
+    font-weight: 900;
+    line-height: 0.5;
+    background-color: colors.$MARK_HIGHLIGHT;
+    border-radius: 8px;
+  }
+
+  .over {
+    color: colors.$RED;
+  }
+
+  .under {
+    color: colors.$BLUE;
+  }
+}

--- a/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
+++ b/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
@@ -15,8 +15,8 @@ interface Score {
 }
 
 const getIndicatorType = (scoreDifference: number) => {
-  if (scoreDifference < 0) return 'less'
-  if (scoreDifference > 0) return 'more'
+  if (scoreDifference < 0) return 'more'
+  if (scoreDifference > 0) return 'less'
   return 'same'
 }
 
@@ -46,8 +46,8 @@ const CompareScoreChart = () => {
             <mark
               className={cx(
                 styles.highlight,
-                { [styles.over]: scoreDifference > 0 },
-                { [styles.under]: scoreDifference < 0 }
+                { [styles.over]: scoreDifference < 0 },
+                { [styles.under]: scoreDifference > 0 }
               )}
             >
               {scoreDifference}점 {comparativeIndicator.text}
@@ -69,7 +69,6 @@ const CompareScoreChart = () => {
               data: { fill: ({ datum }) => (datum.indicator === '나' ? '#F9D548' : '#EF8A4E') },
               labels: { fontSize: 18 },
             }}
-            // barRatio={6}
             barWidth={70}
             cornerRadius={{ top: 8 }}
           />

--- a/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
+++ b/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
@@ -25,10 +25,10 @@ const CompareScoreChart = () => {
       <p className={styles.description}>
         10년 후 예상 건강점수는
         <br />
-        {scoreDifference === 0 && <span>현재와 같아요.</span>}
+        {scoreDifference === 0 && '현재와 같아요.'}
         {scoreDifference !== 0 && (
-          <span>
-            현재보다{' '}
+          <>
+            {'현재보다 '}
             <mark
               className={cx(
                 styles.highlight,
@@ -38,7 +38,7 @@ const CompareScoreChart = () => {
             >
               {scoreDifference}점 {comparativeIndicator.text}
             </mark>
-          </span>
+          </>
         )}
       </p>
       <VictoryChart domainPadding={{ x: 50 }}>

--- a/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
+++ b/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
@@ -1,0 +1,96 @@
+import { VictoryAxis, VictoryBar, VictoryChart, VictoryGroup, VictoryLine, VictoryScatter } from 'victory'
+import cx from 'classnames'
+
+import json from 'assets/json/response.json'
+
+import styles from './compareScoreChart.module.scss'
+import { CallbackArgs } from 'victory-core'
+
+const WHSCORE = json.wxcResultMap.wHscore
+const WHSCORYDY = json.wxcResultMap.wHscoreDy.replace(/\[|\]/g, '').split(', ').at(-1)
+
+interface Score {
+  indicator: string
+  score: number
+}
+
+const getIndicatorType = (scoreDifference: number) => {
+  if (scoreDifference < 0) return 'less'
+  if (scoreDifference > 0) return 'more'
+  return 'same'
+}
+
+const CompareScoreChart = () => {
+  const chartData: Score[] = [
+    { indicator: '나', score: Number(WHSCORE) },
+    { indicator: '10년 후', score: Number(WHSCORYDY) },
+  ]
+  const scoreDifference = chartData[0].score - chartData[1].score
+  // TODO: 색상 hex로
+  const comparativeIndicator = {
+    less: { text: '낮아요', color: 'red' },
+    same: { text: '같아요', color: 'black' },
+    more: { text: '높아요', color: 'blue' },
+  }[getIndicatorType(scoreDifference)]
+
+  return (
+    <div className={styles.comparativeChart}>
+      <h1 className={styles.chartTitle}>나의 10년 후 건강 예측</h1>
+      <p className={styles.description}>
+        10년 후 예상 건강점수는
+        <br />
+        {scoreDifference === 0 && <span>현재와 같아요.</span>}
+        {scoreDifference !== 0 && (
+          <span>
+            현재보다{' '}
+            <mark
+              className={cx(
+                styles.highlight,
+                { [styles.over]: scoreDifference > 0 },
+                { [styles.under]: scoreDifference < 0 }
+              )}
+            >
+              {scoreDifference}점 {comparativeIndicator.text}
+            </mark>
+          </span>
+        )}
+      </p>
+      <VictoryChart domainPadding={{ x: 50 }}>
+        <VictoryAxis
+          tickValues={chartData.map((el) => el.indicator)}
+          style={{ axis: { display: 'none' }, tickLabels: { fontWeight: 700, fontSize: 20 } }}
+        />
+        <VictoryGroup data={chartData} x='indicator' y='score'>
+          <VictoryBar
+            x='indicator'
+            y='score'
+            labels={({ datum }) => `${datum.score}점`}
+            style={{
+              data: { fill: ({ datum }) => (datum.indicator === '나' ? '#F9D548' : '#EF8A4E') },
+              labels: { fontSize: 18 },
+            }}
+            // barRatio={6}
+            barWidth={70}
+            cornerRadius={{ top: 8 }}
+          />
+          <VictoryLine x='indicator' y='score' />
+          <VictoryScatter
+            x='indicator'
+            y='score'
+            style={{
+              data: {
+                fill: ({ datum }) => (datum.indicator === '나' ? 'pink' : 'gold'),
+                stroke: ({ datum }) => (datum.indicator === '나' ? 'red' : 'orange'),
+                fillOpacity: 0.7,
+                strokeWidth: 2,
+              },
+            }}
+            size={6}
+          />
+        </VictoryGroup>
+      </VictoryChart>
+    </div>
+  )
+}
+
+export default CompareScoreChart

--- a/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
+++ b/src/routes/HealthCare/Chart/CompareScoreChart/index.tsx
@@ -1,37 +1,23 @@
 import { VictoryAxis, VictoryBar, VictoryChart, VictoryGroup, VictoryLine, VictoryScatter } from 'victory'
 import cx from 'classnames'
 
-import json from 'assets/json/response.json'
-
 import styles from './compareScoreChart.module.scss'
-import { CallbackArgs } from 'victory-core'
-
-const WHSCORE = json.wxcResultMap.wHscore
-const WHSCORYDY = json.wxcResultMap.wHscoreDy.replace(/\[|\]/g, '').split(', ').at(-1)
-
-interface Score {
-  indicator: string
-  score: number
-}
-
-const getIndicatorType = (scoreDifference: number) => {
-  if (scoreDifference < 0) return 'more'
-  if (scoreDifference > 0) return 'less'
-  return 'same'
-}
+import chartData from './jsonToChartData'
 
 const CompareScoreChart = () => {
-  const chartData: Score[] = [
-    { indicator: '나', score: Number(WHSCORE) },
-    { indicator: '10년 후', score: Number(WHSCORYDY) },
-  ]
   const scoreDifference = chartData[0].score - chartData[1].score
-  // TODO: 색상 hex로
+
+  const getIndicatorType = () => {
+    if (scoreDifference < 0) return 'more'
+    if (scoreDifference > 0) return 'less'
+    return 'same'
+  }
+
   const comparativeIndicator = {
-    less: { text: '낮아요', color: 'red' },
-    same: { text: '같아요', color: 'black' },
-    more: { text: '높아요', color: 'blue' },
-  }[getIndicatorType(scoreDifference)]
+    less: { text: '낮아요' },
+    same: { text: '같아요' },
+    more: { text: '높아요' },
+  }[getIndicatorType()]
 
   return (
     <div className={styles.comparativeChart}>

--- a/src/routes/HealthCare/Chart/CompareScoreChart/jsonToChartData.ts
+++ b/src/routes/HealthCare/Chart/CompareScoreChart/jsonToChartData.ts
@@ -1,0 +1,16 @@
+import json from 'assets/json/response.json'
+
+const WHSCORE = json.wxcResultMap.wHscore
+const WHSCORYDY = json.wxcResultMap.wHscoreDy.replace(/\[|\]/g, '').split(', ').at(-1)
+
+interface Score {
+  indicator: string
+  score: number
+}
+
+const chartData: Score[] = [
+  { indicator: '나', score: Number(WHSCORE) },
+  { indicator: '10년 후', score: Number(WHSCORYDY) },
+]
+
+export default chartData

--- a/src/routes/HealthCare/Chart/chart.module.scss
+++ b/src/routes/HealthCare/Chart/chart.module.scss
@@ -1,8 +1,0 @@
-.comparativeChart {
-  display: flex;
-  flex-direction: column;
-
-  mark {
-    color: red;
-  }
-}

--- a/src/routes/HealthCare/Chart/index.tsx
+++ b/src/routes/HealthCare/Chart/index.tsx
@@ -1,92 +1,14 @@
 import TenYearChart from './TenYearChart/TenYearChart'
 import PredictionCost from './PredictionCost'
-import { VictoryAxis, VictoryBar, VictoryChart, VictoryLine, VictoryScatter } from 'victory'
-
-import json from 'assets/json/response.json'
-import styles from './chart.module.scss'
-import { CallbackArgs } from 'victory-core'
-
-const WHSCORE = json.wxcResultMap.wHscore
-const WHSCORYDY = json.wxcResultMap.wHscoreDy.replace(/\[|\]/g, '').split(', ').at(-1)
-
-interface Score {
-  indicator: string
-  score: number
-}
-
-const getIndicatorType = (scoreDifferece: number) => {
-  if (scoreDifferece < 0) return 'less'
-  if (scoreDifferece > 0) return 'more'
-  return 'same'
-}
+import CompareScoreChart from './CompareScoreChart'
 
 const Chart = () => {
-  const chartData: Score[] = [
-    { indicator: '나', score: Number(WHSCORE) },
-    { indicator: '10년 후', score: Number(WHSCORYDY) },
-  ]
-
-  const scoreDifferece = chartData[0].score - chartData[1].score
-
-  // TODO: 색상 hex로
-  const comparativeIndicator = {
-    less: { text: '낮아요', color: 'red' },
-    same: { text: '같아요', color: 'black' },
-    more: { text: '높아요', color: 'blue' },
-  }[getIndicatorType(scoreDifferece)]
-
   return (
-    <div className={styles.comparativeChart}>
+    <>
       <TenYearChart />
+      <CompareScoreChart />
       <PredictionCost />
-      <h1>나의 10년 후 건강 예측</h1>
-      <div className={styles.descripton}>
-        <div>10년 후 예상 건강점수는</div>
-        {scoreDifferece === 0 && <div>현재와 같아요.</div>}
-        {scoreDifferece !== 0 && (
-          <div>
-            현재보다{' '}
-            <mark>
-              {scoreDifferece}점 {comparativeIndicator.text}
-            </mark>
-          </div>
-        )}
-      </div>
-      <VictoryChart>
-        <VictoryAxis
-          tickValues={chartData.map((el) => el.indicator)}
-          style={{ axis: { display: 'none' }, tickLabels: { fontWeight: 700, fill: 'pink' } }}
-          domain={{ x: [0, 3] }}
-        />
-        <VictoryBar
-          data={chartData}
-          x='indicator'
-          y='score'
-          labels={({ datum }) => `${datum.score}점`}
-          style={{
-            data: { fill: ({ datum }) => (datum.indicator === '나' ? '#F9D548' : '#EF8A4E') },
-            labels: {
-              fill: ({ datum }: CallbackArgs) => (datum.indicator === '나' ? '#F9D548' : '#EF8A4E'),
-            },
-          }}
-        />
-        <VictoryLine data={chartData} x='indicator' y='score' />
-        <VictoryScatter
-          data={chartData}
-          x='indicator'
-          y='score'
-          style={{
-            data: {
-              fill: ({ datum }) => (datum.indicator === '나' ? 'pink' : 'gold'),
-              stroke: ({ datum }) => (datum.indicator === '나' ? 'red' : 'orange'),
-              fillOpacity: 0.7,
-              strokeWidth: 2,
-            },
-          }}
-          size={6}
-        />
-      </VictoryChart>
-    </div>
+    </>
   )
 }
 export default Chart

--- a/src/routes/HealthCare/index.tsx
+++ b/src/routes/HealthCare/index.tsx
@@ -14,6 +14,7 @@ const HealthCare = () => {
       <div className={styles.kbWrap}>
         <Header />
         <Main />
+        <Chart />
         <UserManagement />
       </div>
     </div>

--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -31,3 +31,5 @@ $MAIN_COLOR: #ffd700;
 $TAG_TITLE: #595959;
 $TAG_MAIN: #ffea71;
 $TAG_SUB: #efefef;
+
+$MARK_HIGHLIGHT: #fdf491;


### PR DESCRIPTION
- 좌우 패딩 먹이지 않았음, 전체에서 패딩 동일하게 주는게 더 적합하다고 판단
- 컴포넌트 분리
- 분리한 차트, 그리고 디자인 업데이트
<img width="544" alt="스크린샷 2022-06-01 오후 12 54 44" src="https://user-images.githubusercontent.com/87363088/171324539-95a4391e-20ec-4962-83eb-3aa7ff88f433.png">


